### PR TITLE
Fix import of shell_commands

### DIFF
--- a/python/netsim_tool/main.py
+++ b/python/netsim_tool/main.py
@@ -20,7 +20,7 @@ import os
 from collections import namedtuple
 from ncs.application import Service
 from ncs.dp import Action
-from shell_commands import NetsimShell
+from netsim_tool.shell_commands import NetsimShell
 
 
 class NetsimTool(Action):


### PR DESCRIPTION
The pythonpath that is setup when we start the package will have:

./state/packages-in-use/1/cli-netsim-tool/python

To import that we need to add
from netsim_tool.shell_commands